### PR TITLE
Support for custom search_path

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,6 @@
     "pascal-case": "^4.0.0",
     "piscina": "^4.0.0",
     "tinypool": "^1.0.0",
-    "ts-parse-database-url": "^1.0.3",
     "yargs": "^17.0.1"
   },
   "devDependencies": {

--- a/packages/example/config.json
+++ b/packages/example/config.json
@@ -25,5 +25,5 @@
     "category": { "return": "./src/customTypes.js#Category" }
   },
   "srcDir": "./src/",
-  "dbUrl": "postgres://postgres:password@localhost/postgres"
+  "dbUrl": "postgres://postgres:password@localhost/postgres?options=-c%20search_path%3Dpublic%2Ccustomschema"
 }

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "test": "docker compose run build && docker compose run test && docker compose run test-cjs",
+    "posttest": "docker compose down -v",
     "typegen": "pgtyped -c config.json",
     "build": "echo 'No build step required. Use npm test instead'",
     "watch": "echo 'No build step required. Use npm test instead'",

--- a/packages/example/sql/schema.sql
+++ b/packages/example/sql/schema.sql
@@ -101,3 +101,11 @@ CREATE TABLE book_country (
 
 INSERT INTO book_country (country)
 VALUES ('CZ'), ('DE');
+
+CREATE SCHEMA IF NOT EXISTS customschema;
+CREATE TABLE customschema.tableincustomschema (
+  id SERIAL PRIMARY KEY,
+  name TEXT
+);
+INSERT INTO customschema.tableincustomschema (name)
+VALUES ('First record in custom schema');

--- a/packages/example/src/__snapshots__/index.test.ts.snap
+++ b/packages/example/src/__snapshots__/index.test.ts.snap
@@ -38,6 +38,15 @@ Array [
 ]
 `;
 
+exports[`select query on table in custom schema 1`] = `
+Array [
+  Object {
+    "id": 1,
+    "name": "First record in custom schema",
+  },
+]
+`;
+
 exports[`select query with dynamic or 1`] = `
 Array [
   Object {

--- a/packages/example/src/custom/custom.queries.ts
+++ b/packages/example/src/custom/custom.queries.ts
@@ -1,0 +1,31 @@
+/** Types generated for queries found in "src/custom/custom.sql" */
+import { PreparedQuery } from '@pgtyped/runtime';
+
+/** 'GetCustomSchemaRecords' parameters type */
+export interface IGetCustomSchemaRecordsParams {
+  id: number;
+}
+
+/** 'GetCustomSchemaRecords' return type */
+export interface IGetCustomSchemaRecordsResult {
+  id: number;
+  name: string | null;
+}
+
+/** 'GetCustomSchemaRecords' query type */
+export interface IGetCustomSchemaRecordsQuery {
+  params: IGetCustomSchemaRecordsParams;
+  result: IGetCustomSchemaRecordsResult;
+}
+
+const getCustomSchemaRecordsIR: any = {"usedParamSet":{"id":true},"params":[{"name":"id","required":true,"transform":{"type":"scalar"},"locs":[{"a":45,"b":48}]}],"statement":"SELECT * FROM tableincustomschema WHERE id = :id!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT * FROM tableincustomschema WHERE id = :id!
+ * ```
+ */
+export const getCustomSchemaRecords = new PreparedQuery<IGetCustomSchemaRecordsParams,IGetCustomSchemaRecordsResult>(getCustomSchemaRecordsIR);
+
+

--- a/packages/example/src/custom/custom.sql
+++ b/packages/example/src/custom/custom.sql
@@ -1,0 +1,3 @@
+/* A query to get records from a table outside the default public schema */
+/* @name GetCustomSchemaRecords */
+SELECT * FROM tableincustomschema WHERE id = :id!;

--- a/packages/example/src/index.test.ts
+++ b/packages/example/src/index.test.ts
@@ -19,6 +19,9 @@ import {
   selectExistsTest,
 } from './comments/comments.queries.js';
 import {
+  getCustomSchemaRecords,
+} from './custom/custom.queries.js';
+import {
   insertNotification,
   insertNotifications,
 } from './notifications/notifications.js';
@@ -39,6 +42,7 @@ const dbConfig = {
   password: process.env.PGPASSWORD ?? 'password',
   database: process.env.PGDATABASE ?? 'postgres',
   port: (process.env.PGPORT ? Number(process.env.PGPORT) : undefined) ?? 5432,
+  options: process.env.PGOPTIONS ?? '-c search_path=public,customschema',
 };
 
 // Connect to the database once before all tests
@@ -236,4 +240,9 @@ test('select query with a bigint field', async () => {
 test('ts-implicit mode query', async () => {
   const books = await sql(`SELECT * FROM books WHERE id = $id`).run({id: 1}, client);
   expect(books).toMatchSnapshot();
+});
+
+test('select query on table in custom schema', async () => {
+  const result = await getCustomSchemaRecords.run({ id: 1 }, client);
+  expect(result).toMatchSnapshot();
 });

--- a/packages/query/src/actions.ts
+++ b/packages/query/src/actions.ts
@@ -34,16 +34,18 @@ export async function startup(
     user: string;
     dbName: string;
     ssl?: tls.ConnectionOptions | boolean;
+    options?: string;
   },
   queue: AsyncQueue,
 ) {
   try {
     await queue.connect(options);
-    const startupParams = {
+    const startupParams: Record<string, string> = {
       user: options.user,
       database: options.dbName,
       client_encoding: "'utf-8'",
     };
+    if (options.options) startupParams.options = options.options;
     await queue.send(messages.startupMessage, { params: startupParams });
     const result = await queue.reply(
       messages.readyForQuery,


### PR DESCRIPTION
Adds support for specifying a custom search_path when generating types so that proper types can be generated for queries which refer to tables outside of 'public' without explicit schema namespacing.